### PR TITLE
Add option to build parser with enabled cache

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,8 @@ var loaderUtils = require('loader-utils');
 module.exports = function(source) {
   this.cacheable && this.cacheable();
   var query = loaderUtils.parseQuery(this.query);
-  var pegOptions = { output: 'source' };
-  var parser = 'module.exports = ' + pegjs.buildParser(source, pegOptions) + ';';
-  this.callback(null, parser, null);
+  var cacheParserResults = !!query.cache;
+  // Description of PEG.js options: https://github.com/pegjs/pegjs#javascript-api
+  var pegOptions = { output: 'source', cache: cacheParserResults };
+  return 'module.exports = ' + pegjs.buildParser(source, pegOptions) + ';';
 };


### PR DESCRIPTION
Usage: `require('pegjs?cache!parser.pegjs')`