### PR TITLE
Support the 'optimize' option of buildParser() to specify 'speed' or 'size' preference

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,9 +8,14 @@ export default function loader(source) {
 
   const query = loaderUtils.parseQuery(this.query);
   const cacheParserResults = !!query.cache;
+  const optimizeParser = query.optimize || 'speed';
 
   // Description of PEG.js options: https://github.com/pegjs/pegjs#javascript-api
-  const pegOptions = { output: 'source', cache: cacheParserResults };
+  const pegOptions = {
+    output: 'source',
+    cache: cacheParserResults,
+    optimize: optimizeParser
+  };
 
   return `module.exports = ${pegjs.buildParser(source, pegOptions)};`;
 }


### PR DESCRIPTION
Current versions of PEG.js support option "optimize" for `buildParser()` with possible values of "speed" (default) or "size". Being able to specify those choices with pegjs-loader is helpful.