### PR TITLE
Add allowedStartRules and trace options

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ You can pass options to PEG.js as [query parameters](http://webpack.github.io/do
   * `optimize` - whether to optimize the built parser either for `speed` or
     `size` (default: `speed`)
 
+  * `allowedStartRules` - The rules the built parser will be allowed to start
+    parsing from (default: the first rule in the grammar).
+
+  * `trace` - if `true`, the tracing support in the built parser is enabled
+    (default: `false`)
+
 ``` js
 module.exports = {
   ...
@@ -58,7 +64,7 @@ module.exports = {
     loaders: [
       {
         test: /\.pegjs$/,
-        loader: 'pegjs-loader?cache=true&optimize=size'
+        loader: 'pegjs-loader?cache=true&optimize=size&allowedStartRules[]=RuleA,allowedStartRules[]=RuleB&trace=false'
       }
     ]
   }

--- a/src/index.js
+++ b/src/index.js
@@ -9,13 +9,27 @@ export default function loader(source) {
   const query = loaderUtils.parseQuery(this.query);
   const cacheParserResults = !!query.cache;
   const optimizeParser = query.optimize || 'speed';
+  const trace = !!query.trace;
+
+  let allowedStartRules;
+  if (typeof query.allowedStartRules === 'string') {
+    allowedStartRules = [ query.allowedStartRules ];
+  } else if (Array.isArray(query.allowedStartRules)) {
+    allowedStartRules = query.allowedStartRules;
+  } else {
+    allowedStartRules = [];
+  }
 
   // Description of PEG.js options: https://github.com/pegjs/pegjs#javascript-api
   const pegOptions = {
     output: 'source',
     cache: cacheParserResults,
     optimize: optimizeParser,
+    trace: trace,
   };
+  if (allowedStartRules.length > 0) {
+    pegOptions.allowedStartRules = allowedStartRules;
+  }
 
   return `module.exports = ${pegjs.buildParser(source, pegOptions)};`;
 }


### PR DESCRIPTION
Add option to build parsers with multiple start-rules (`allowedStartRules`) and the `trace` option introduced in PEG.js v0.9.