### PR TITLE
Updating pegjs-loader to work with pegjs 0.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "http://eploko.github.io/pegjs-loader",
   "peerDependencies": {
-    "pegjs": "^0.9.0",
+    "pegjs": "^0.10.0",
     "webpack": "^1.12.2"
   },
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -31,5 +31,6 @@ export default function loader(source) {
     pegOptions.allowedStartRules = allowedStartRules;
   }
 
-  return `module.exports = ${pegjs.buildParser(source, pegOptions)};`;
+  const methodName = (typeof pegjs.generate === 'function') ? 'generate' : 'buildParser';
+  return `module.exports = ${pegjs[methodName](source, pegOptions)};`;
 }


### PR DESCRIPTION
In the just-released pegjs 0.10.0, they decided to rename method 'buildParser' to 'generate'. Thus, pegjs-loader needs an update to correctly work with this new public version of pegjs.

(The proposed code change keeps backward compatibility with the old method name, just in the case if some people still need to use the previous version of pegjs, for some more time.)