### PR TITLE
Make webpack peer dependency compatible with 2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "http://eploko.github.io/pegjs-loader",
   "peerDependencies": {
     "pegjs": "^0.10.0",
-    "webpack": "^1.12.2"
+    "webpack": "1 || 2 || ^2.1.0-beta || ^2.2.0-rc"
   },
   "dependencies": {
     "loader-utils": "^0.2.5"


### PR DESCRIPTION
We're using this loader with webpack 2.2.0-rc1 with no problems.
This would eliminate the warnings in yarn/npm about unmet peer dependencies 